### PR TITLE
Add initial utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,50 @@
 
 Custom system-level features and software for [VVV](https://github.com/varying-vagrant-vagrants/vvv/).
 
-Leveraged by these additions to `config/config.yml`:
+## What's included
+
+### coretech
+
+Creates a local cache of Core Tech to expedite provisioning of individual sites.
+
+Included are `pmc-plugins`, `pmc-vip-go-plugins`, and any theme used by multiple
+sites.
+
+Unlike in previous `pmc-vvv` iterations, these caches are not symlink targets 
+due to limitations in PHP's symlink support, which interfere with WordPress
+functions that we rely on.
+
+### dev-tools
+
+**Optional**
+
+Installs assorted developer tools not included with VVV, such as `awscli`, `jq`,
+and `yaml2json`.
+
+### http-concat
+
+Adds the necessary nginx configuration to enable VIP Go's CSS and JS 
+concatenation library.
+
+### phpcs
+
+Installs PMC's [PHCPS standards](https://bitbucket.org/penskemediacorp/pmc-codesniffer) and sets `PmcWpVip` as the default standard. 
+
+## Using
+
+If you're using [pmc-vvv](https://github.com/penske-media-corp/pmc-vvv), the
+following configurations are already present in `config.yml`, though optional
+utilities may be omitted.
+
+Otherwise, these are leveraged by these additions to `config.yml`:
 
 ```yaml
 utilities:
   pmc:
-    - phpcs # PMC's PHPCS rules
+    - coretech      # Speed provisioning of shared code
+    # - dev-tools   # Various utilities developers may find handy (optional)
+    - http-concat   # VIP Go's nginx concatenation
+    - phpcs         # PMC's PHPCS rules
 
 utility-sources:
   pmc:

--- a/coretech/provision.sh
+++ b/coretech/provision.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CORETECH_DIR="/tmp/pmc-coretech"
+
+REPO_LIST="/srv/provision/utilities/pmc/coretech/repos.yml"
+
+vvv_info " * Preparing to clone common code for reuse during site provisioning..."
+
+rm -rf "$CORETECH_DIR"
+noroot mkdir "$CORETECH_DIR"
+cd "$CORETECH_DIR"
+
+vvv_info " * Starting clone operations..."
+
+set +e
+noroot shyaml get-values-0 < "${REPO_LIST}" |
+while IFS='' read -r -d '' key &&
+      IFS='' read -r -d '' value; do
+  echo " * Cloning '${value}' into '${CORETECH_DIR}/${key}'"
+  noroot git clone --recursive --quiet "${value}" "${CORETECH_DIR}/${key}"
+done
+set -e
+

--- a/coretech/repos.yml
+++ b/coretech/repos.yml
@@ -1,0 +1,6 @@
+mu-plugins: git@github.com:Automattic/vip-go-mu-plugins-built.git
+plugins: git@bitbucket.org:penskemediacorp/pmc-vip-go-plugins.git
+plugins/pmc-plugins: git@bitbucket.org:penskemediacorp/pmc-plugins.git
+themes/pmc-core-2017: git@bitbucket.org:penskemediacorp/pmc-core-2017.git
+themes/pmc-core-v2: git@bitbucket.org:penskemediacorp/pmc-core-v2.git
+themes/pmc-summits: git@bitbucket.org:penskemediacorp/pmc-summits.git

--- a/dev-tools/provision.sh
+++ b/dev-tools/provision.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+npm install -g coolaj86/yaml2json
+
+apt-get update
+
+apt-get install -y \
+  awscli \
+  git-extras \
+  httpie \
+  jq \
+  neovim \
+  ranger \
+  siege \
+  tig \
+  vifm
+
+apt-get clean -y

--- a/http-concat/nginx-http-concat.conf
+++ b/http-concat/nginx-http-concat.conf
@@ -1,0 +1,7 @@
+
+# Support VIP's nginx-http-concat plugin.
+location /_static/ {
+  fastcgi_pass $upstream;
+  include /etc/nginx/fastcgi_params;
+  fastcgi_param SCRIPT_FILENAME $document_root/wp-content/mu-plugins/http-concat/ngx-http-concat.php;
+}

--- a/http-concat/provision.sh
+++ b/http-concat/provision.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+PROVISION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+COMMON_CONFIG=/etc/nginx/nginx-wp-common.conf
+
+INSERT_MARKER="charset utf-8;"
+CHECK_STRING="/_static/"
+
+CONCAT_CONFIG="${PROVISION_DIR}/nginx-http-concat.conf"
+
+# Ignoring as pipefail interferes, as cautioned in sniff help.
+# shellcheck disable=SC2143
+if [ -n "$(grep "$CHECK_STRING" "$COMMON_CONFIG")" ]; then
+  vvv_info " * Nothing to do"
+  return
+fi
+
+vvv_info " * Adding nginx-concat configuration to ${COMMON_CONFIG}"
+
+sed -i -e "/${INSERT_MARKER}/r${CONCAT_CONFIG}" "$COMMON_CONFIG"

--- a/phpcs/provision.sh
+++ b/phpcs/provision.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+STANDARDS_DIR="/srv/www/phpcs/CodeSniffer/Standards/"
+
+vvv_info " * Removing PHCPS standards provisioned by VVV..."
+rm -rf $STANDARDS_DIR
+
+vvv_info " * Install PMC Codesniffer..."
+git clone git@bitbucket.org:penskemediacorp/pmc-codesniffer.git "$STANDARDS_DIR"
+noroot composer update --no-ansi --no-autoloader --no-progress -d "$STANDARDS_DIR"
+
+vvv_info " * Setting PmcWpVip as default PHPCS standard..."
+phpcs --config-set installed_paths ./CodeSniffer/Standards/PmcWpVip/,./CodeSniffer/Standards/PmcLaravel/,./CodeSniffer/Standards/vendor/wp-coding-standards/wpcs/,./CodeSniffer/Standards/vendor/automattic/vipwpcs/,./CodeSniffer/Standards/vendor/sirbrillig/phpcs-variable-analysis/
+phpcs --config-set default_standard PmcWpVip
+phpcs -i
+phpcs --config-show


### PR DESCRIPTION
VVV provides a mechanism called "utilities" to install additional software in a VVV instance. These utilities are enabled in PMC's new default VVV configuration, and are required to complete a successful provisioning using our custom provisioner.

The four utilities included herein:

- cache Core Tech to expedite individual-site provisioning, akin to the symlink target previously employed
- enable VIP Go's concatenation feature
- install and activate PMC's PHPCS rules
- install various developer tools

Depends on https://github.com/penske-media-corp/pmc-vvv-site-provisioners/pull/1 and enabled by the configuration in https://github.com/penske-media-corp/pmc-vvv/pull/10.