### PR TITLE
Trust all git repos inside the VM

### DIFF
--- a/coretech/provision.sh
+++ b/coretech/provision.sh
@@ -5,6 +5,14 @@ CORETECH_DIR="/tmp/pmc-coretech"
 PROVISION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 REPO_LIST="${PROVISION_DIR}/repos.yml"
 
+function pmc_git_trust_all() {
+  git config --global --add safe.directory '*'
+}
+
+vvv_info " * Forcing git to trust all repos..."
+pmc_git_trust_all
+noroot pmc_git_trust_all
+
 vvv_info " * Preparing to clone common code for reuse during site provisioning..."
 
 rm -rf "$CORETECH_DIR"
@@ -17,7 +25,7 @@ set +e
 noroot shyaml get-values-0 < "${REPO_LIST}" |
 while IFS='' read -r -d '' key &&
       IFS='' read -r -d '' value; do
-  echo " * Cloning '${value}' into '${CORETECH_DIR}/${key}'"
+  vvv_info "  + Cloning '${value}' into '${CORETECH_DIR}/${key}'"
   noroot git clone --recursive --quiet "${value}" "${CORETECH_DIR}/${key}"
 done
 set -e


### PR DESCRIPTION
Beginning with git 2.35.2, git will refuse to interact with repositories owned
by other users due to changes made to address CVE-2022-24765. Inside our VM, we
care not who owns a repository, so we tell git to trust everything.

See https://github.blog/2022-04-12-git-security-vulnerability-announced/