### PR TITLE
Switch `client-mu-plugins` to use canonical repo

### DIFF
--- a/coretech/repos.yml
+++ b/coretech/repos.yml
@@ -1,3 +1,4 @@
+client-mu-plugins: git@github.com:penske-media-corp/pmc-vip-client-mu-plugins.git
 mu-plugins: git@github.com:Automattic/vip-go-mu-plugins-built.git
 plugins: git@github.com:penske-media-corp/pmc-vip-go-plugins.git
 plugins/pmc-plugins: git@github.com:penske-media-corp/pmc-plugins.git


### PR DESCRIPTION
Dependency for https://github.com/penske-media-corp/pmc-vvv-site-provisioners/pull/18.